### PR TITLE
Properly recurse into child deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>18.0</version>
+        <version>28.2-jre</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -98,7 +98,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.4</version>
+          <version>3.5</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/main/java/com/hubspot/maven/plugins/dependency/scope/DependencyViolation.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/scope/DependencyViolation.java
@@ -1,6 +1,11 @@
 package com.hubspot.maven.plugins.dependency.scope;
 
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
 import org.eclipse.aether.graph.Dependency;
+
+import com.google.common.collect.ImmutableList;
 
 public class DependencyViolation {
   private final TraversalContext source;
@@ -13,6 +18,14 @@ public class DependencyViolation {
 
   public TraversalContext getSource() {
     return source;
+  }
+
+  public List<String> getPath() {
+    ImmutableList.Builder<String> builder = ImmutableList.builder();
+    source.path().stream().map(Artifact::toString).forEach(builder::add);
+    builder.add(dependency.getArtifact().toString());
+
+    return builder.build();
   }
 
   public Dependency getDependency() {


### PR DESCRIPTION
I noticed a dependency issue that this plugin didn't catch and it turns out that the implementation has a flaw that means we can miss a bunch of test-scoped dep issues. The main issue is that we currently iterate over child nodes in the dep tree:
https://github.com/HubSpot/dependency-scope-maven-plugin/blob/4950b9b5e64b574352b1b6dc21fc75801737bb5d/src/main/java/com/hubspot/maven/plugins/dependency/scope/DependencyScopeMojo.java#L142

However, this is the resolved dep tree, and we want something closer to the verbose dep tree. This PR updates things to iterate over the dependencies returned by the pom lookup, which should be what we want:
https://github.com/HubSpot/dependency-scope-maven-plugin/blob/b773a6c81d3cccd42d40f434dfa257185d5b9b38/src/main/java/com/hubspot/maven/plugins/dependency/scope/DependencyScopeMojo.java#L142

There were a bunch of other changes needed in support of this, but that's the main idea
 